### PR TITLE
fix(train): move GitStatusChecker out of module level to prevent Dock…

### DIFF
--- a/anomavision/train.py
+++ b/anomavision/train.py
@@ -11,12 +11,12 @@ from torch.utils.data import DataLoader
 
 import anomavision
 from anomavision.config import load_config
-from anomavision.general import GitStatusChecker, increment_path
-from anomavision.utils import get_logger, merge_config, save_args_to_yaml, setup_logging
-
-# Check git status at module level (optional, can be moved to main if preferred)
-checker = GitStatusChecker()
-checker.check_status()
+from anomavision.general import GitStatusChecker
+from anomavision.general import increment_path
+from anomavision.utils import get_logger
+from anomavision.utils import merge_config
+from anomavision.utils import save_args_to_yaml
+from anomavision.utils import setup_logging
 
 
 def create_parser(add_help: bool = True) -> argparse.ArgumentParser:
@@ -281,6 +281,14 @@ def main(args=None):
     try:
         if args is None:
             args = create_parser().parse_args()
+
+        # Optional git check — silently skipped if not in a repo or no network
+        try:
+            checker = GitStatusChecker()
+            if checker.is_repo():
+                checker.check_status()
+        except Exception:
+            pass  # Never block training over a git check
 
         run_training(args)
 


### PR DESCRIPTION
## Problem

The `GitStatusChecker` was instantiated and executed at **module level** in `train.py`:

```python
# Ran on every import — even for --help
checker = GitStatusChecker()
checker.check_status()
```

This caused two issues:

1. **Docker crash** — `git fetch` fails inside containers that have no git remote, no SSH keys, or no `git` binary. Because `subprocess.run` uses `check=True`, it raises `CalledProcessError` and kills the process before training starts.
2. **Import side effect** — any code that imports `anomavision.train` (including `cli.py` building the argument parser for `--help`) would trigger a network call unconditionally.

## Fix

Moved the git check inside `main()` with two additional guards:
- Only runs if actually inside a git repository (`checker.is_repo()`)
- Wrapped in `try/except` so a git failure never blocks training

```python
try:
    checker = GitStatusChecker()
    if checker.is_repo():
        checker.check_status()
except Exception:
    pass  # Never block training over a git check
```

## Impact

- Fixes CLI commands not being accessible in Docker (related to #<issue_number>)
- No change to training behavior
- Git status check still runs when training locally inside a valid repo

## Testing

- [ ] `anomavision train --help` works inside Docker without errors
- [ ] `anomavision train --config config.yml` runs successfully
- [ ] Git status check still prints when running locally in a valid repo