### PR TITLE
fix(dataset): remove incorrect BGR2RGB conversion causing color disto…

### DIFF
--- a/anomavision/datasets/dataset.py
+++ b/anomavision/datasets/dataset.py
@@ -103,7 +103,7 @@ class AnodetDataset(Dataset):
         image = Image.open(self.image_paths[idx]).convert("RGB")
         batch = self.image_transforms(image)
         image = np.array(image)
-        image = cv.cvtColor(image, cv.COLOR_BGR2RGB)
+        # image = cv.cvtColor(image, cv.COLOR_BGR2RGB)
 
         # Load mask if mask_directory_path argument is given
         if self.mask_directory_path is not None:

--- a/anomavision/detect.py
+++ b/anomavision/detect.py
@@ -428,11 +428,10 @@ def run_inference(args):
             if config.enable_visualization:
                 with profilers["visualization"]:
                     try:
-                        test_images = np.array(images)
 
                         boundary_images = (
                             anomavision.visualization.framed_boundary_images(
-                                test_images,
+                                images,
                                 (
                                     anomavision.classification(
                                         score_maps, config.thresh
@@ -446,7 +445,7 @@ def run_inference(args):
                         )
 
                         heatmap_images = anomavision.visualization.heatmap_images(
-                            test_images,
+                            images,
                             score_maps,
                             alpha=config.get("viz_alpha", 0.5),
                         )


### PR DESCRIPTION

PIL's Image.open().convert('RGB') already loads images in RGB format. Applying cv.cvtColor(image, cv.COLOR_BGR2RGB) incorrectly assumes the input is BGR, which swaps the Red and Blue channels. This caused the visualized 'Original' images to appear with a blue/purple tint. Removed the unnecessary OpenCV color conversion to preserve the correct RGB format for matplotlib visualization.

## 🔗 Related Issue
Fixes #

## 📝 Description
-
-
-

## 🔄 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🏗️ Infrastructure / CI/CD update

## 🧪 Hardware & Matrix Testing
**I have successfully built and tested this code using `uv` on:**
- [x] `anomavision[cpu]` (Standard/Edge)
- [ ] `anomavision[cu121]` (CUDA 12.1)
- [ ] `anomavision[cu124]` (CUDA 12.4)
- [ ] `anomavision[cu118]` (CUDA 11.8)

**Host OS used for testing:**
- [ ] Linux / Ubuntu
- [ ] Windows (Native or WSL2)
- [ ] macOS

## ✅ Developer Checklist
- [x] My code follows the core style guidelines of this project (Ruff/Black formatting).
- [x] I have run `uv run pytest` and all unit tests pass locally.
- [ ] **Lockfile Guard:** If I added or modified a dependency in `pyproject.toml`, I have run `uv lock --python 3.10` and committed the updated `uv.lock` file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation accordingly (if applicable).

## 📸 Screenshots / Visual Proof (Optional)
