### PR TITLE
Fix/kv260 padim xmodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ AnomaVision supports **PaDiM** and lightweight **PatchCore**, image-level scores
 - Use **PaDiM** for the default fast baseline or **PatchCore** for a compact nearest-neighbor memory bank.
 - Run inference through PyTorch, ONNX Runtime, OpenVINO, or native TensorRT.
 - Export FP16 or calibrated INT8 TensorRT engines for NVIDIA production deployments.
+- **Export and compile PaDiM and PatchCore to Vitis AI XModel for the AMD/Xilinx Kria KV260.**
 
 Benchmark results and reproduction details are documented in [`docs/benchmark.md`](docs/benchmark.md). Treat benchmark numbers as workload-specific, and reproduce them on your own hardware before making production claims.
 
@@ -112,6 +113,71 @@ anomavision train --help
 anomavision export --help
 ```
 
+## KV260 XModel deployment
+
+AnomaVision also provides a Vitis AI workflow for deploying **PaDiM** and **PatchCore** on the **AMD/Xilinx Kria KV260** DPU.
+
+The KV260 workflow is:
+
+**PyTorch model → Vitis AI INT8 quantization → XModel → KV260 DPU compilation**
+
+The detailed, copy-ready guide is available in [`docs/kv260_xmodel.md`](docs/kv260_xmodel.md).
+
+The guide covers:
+
+- Vitis AI 3.5 environment setup
+- PaDiM INT8 calibration and test mode
+- PatchCore INT8 calibration and test mode
+- XModel validation
+- KV260 DPU compilation with `vai_c_xir`
+- Expected output files and troubleshooting notes
+
+### PaDiM quick example
+
+```bash
+python quantize_padim_kv260.py \
+  --model distributions/padim/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_padim_kv260 \
+  --quant_mode calib
+
+python quantize_padim_kv260.py \
+  --model distributions/padim/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_padim_kv260 \
+  --quant_mode test
+
+vai_c_xir \
+  -x compiled_padim_kv260/PadimKV260_int.xmodel \
+  -a /opt/vitis_ai/compiler/arch/DPUCZDX8G/KV260/arch.json \
+  -o compiled_padim_kv260/compiled \
+  -n PadimKV260
+```
+
+### PatchCore quick example
+
+```bash
+python quantize_patchcore_kv260.py \
+  --model distributions/patchcore/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_patchcore_kv260 \
+  --quant_mode calib
+
+python quantize_patchcore_kv260.py \
+  --model distributions/patchcore/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_patchcore_kv260 \
+  --quant_mode test
+
+vai_c_xir \
+  -x compiled_patchcore_kv260/PatchCoreKV260_int.xmodel \
+  -a /opt/vitis_ai/compiler/arch/DPUCZDX8G/KV260/arch.json \
+  -o compiled_patchcore_kv260/compiled \
+  -n PatchCoreKV260
+```
+
+> **Note:** KV260 XModel generation and compilation are intended for a Linux/Vitis AI environment. The final on-device KV260 validation is a separate step from XModel generation and compiler validation.
+
 ## Production Autopilot
 
 **Production Autopilot is the easiest way to move from two trained models to one deployable choice.** It compares PaDiM and ultra-light PatchCore on the same labeled test split, calibrates a separate threshold for each, profiles median and P95 latency on your hardware, checks localization health, and packages the selected artifact with a self-contained HTML dashboard.
@@ -163,6 +229,7 @@ PatchCore compares image patches with a compact normal-feature memory bank. Its 
 | CLI and configuration | [`docs/cli.md`](docs/cli.md), [`docs/config.md`](docs/config.md) |
 | Python API | [`docs/api.md`](docs/api.md) |
 | PatchCore and TensorRT deployment | [`docs/production_deployment.md`](docs/production_deployment.md) |
+| **KV260 PaDiM/PatchCore XModel** | [`docs/kv260_xmodel.md`](docs/kv260_xmodel.md) |
 | Runnable CPU, PatchCore, and TensorRT examples | [`examples/README.md`](examples/README.md) |
 | Benchmark methodology | [`docs/benchmark.md`](docs/benchmark.md) |
 | Troubleshooting | [`docs/troubleshooting.md`](docs/troubleshooting.md) |

--- a/anomavision/inference/model/backends/k260_backend.py
+++ b/anomavision/inference/model/backends/k260_backend.py
@@ -86,7 +86,9 @@ class KV260Backend(InferenceBackend):
             )
 
         self.input_tensor = self.input_tensors[0]
-        self.output_names = [getattr(tensor, "name", "") for tensor in self.output_tensors]
+        self.output_names = [
+            getattr(tensor, "name", "") for tensor in self.output_tensors
+        ]
         self.input_shape = tuple(int(value) for value in self.input_tensor.dims)
 
     @staticmethod
@@ -139,8 +141,7 @@ class KV260Backend(InferenceBackend):
             for buffer in input_buffers:
                 buffer.sync_for_write(
                     0,
-                    buffer.get_tensor().get_data_size()
-                    // buffer.get_tensor().dims[0],
+                    buffer.get_tensor().get_data_size() // buffer.get_tensor().dims[0],
                 )
             job_id, status = self.runner.execute_async(input_buffers, output_buffers)
             if status != 0:
@@ -151,8 +152,7 @@ class KV260Backend(InferenceBackend):
             for buffer in output_buffers:
                 buffer.sync_for_read(
                     0,
-                    buffer.get_tensor().get_data_size()
-                    // buffer.get_tensor().dims[0],
+                    buffer.get_tensor().get_data_size() // buffer.get_tensor().dims[0],
                 )
             outputs = [np.asarray(buffer).copy() for buffer in output_buffers]
         else:

--- a/anomavision/inference/model/backends/k260_backend.py
+++ b/anomavision/inference/model/backends/k260_backend.py
@@ -12,7 +12,12 @@ from .base import InferenceBackend, ScoresMaps
 
 
 class KV260Backend(InferenceBackend):
-    """Run an AMD Vitis AI XModel through VART on a KV260/K26 target."""
+    """Run an AMD Vitis AI XModel through VART on a KV260/K26 target.
+
+    Compiled AnomaVision XModels can contain both DPU and CPU subgraphs.  When
+    the Vitis AI GraphRunner is available, use it so the complete graph is
+    executed instead of accidentally running only the first child subgraph.
+    """
 
     def __init__(
         self,
@@ -20,22 +25,12 @@ class KV260Backend(InferenceBackend):
         device: str = "k260",
         input_size: tuple[int, int] = (224, 224),
     ) -> None:
-        """Load an AMD Vitis AI XModel through the VART runtime.
-
-        Args:
-            model_path: Path to an XModel exposing image score and map outputs.
-            device: Board identifier retained for backend-factory consistency.
-            input_size: Fixed ``(height, width)`` used for RGB preprocessing.
-
-        Raises:
-            FileNotFoundError: If ``model_path`` does not exist.
-            RuntimeError: If VART/XIR is unavailable or no runnable subgraph exists.
-            ValueError: If the XModel does not expose at least two outputs.
-        """
+        """Load an AMD Vitis AI XModel through the VART runtime."""
         del device
         self.model_path = Path(model_path)
         if not self.model_path.is_file():
             raise FileNotFoundError(self.model_path)
+
         try:
             import vart
             import xir
@@ -43,20 +38,55 @@ class KV260Backend(InferenceBackend):
             raise RuntimeError(
                 "Vitis AI VART/XIR is required for KV260 XModel inference."
             ) from exc
+
         self._vart = vart
         self.input_size = tuple(int(value) for value in input_size)
-        graph = xir.Graph.deserialize(str(self.model_path))
-        runners = graph.get_root_subgraph().children_topological_sort()
-        if not runners:
-            raise RuntimeError(f"No runnable subgraph found in {self.model_path}")
-        self.runner = vart.Runner.create_runner(runners[0], "run")
-        self.input_tensor = self.runner.get_input_tensors()[0]
-        self.output_tensors = self.runner.get_output_tensors()
+        self.graph = xir.Graph.deserialize(str(self.model_path))
+        self.runner = None
+        self._graph_runner = False
+
+        # A compiled XModel may be split into DPU + CPU subgraphs. GraphRunner
+        # is the Vitis AI API intended for executing such complete graphs.
+        try:
+            from vitis_ai_library import GraphRunner
+
+            self.runner = GraphRunner.create_graph_runner(self.graph)
+            self._graph_runner = True
+            self.input_tensors = [
+                buffer.get_tensor() for buffer in self.runner.get_inputs()
+            ]
+            self.output_tensors = [
+                buffer.get_tensor() for buffer in self.runner.get_outputs()
+            ]
+        except (ImportError, AttributeError, RuntimeError) as exc:
+            # Keep a VART-only fallback for single-DPU XModels. This is useful
+            # for minimal graphs, but cannot execute CPU post-processing nodes.
+            children = self.graph.get_root_subgraph().toposort_child_subgraph()
+            dpu_children = [
+                child
+                for child in children
+                if child.has_attr("device") and child.get_attr("device") == "DPU"
+            ]
+            if len(dpu_children) != 1:
+                raise RuntimeError(
+                    "This XModel contains multiple subgraphs and requires "
+                    "Vitis AI GraphRunner (vitis_ai_library)."
+                ) from exc
+
+            self.runner = vart.Runner.create_runner(dpu_children[0], "run")
+            self.input_tensors = self.runner.get_input_tensors()
+            self.output_tensors = self.runner.get_output_tensors()
+
+        if not self.input_tensors:
+            raise RuntimeError(f"No input tensor found in {self.model_path}")
         if len(self.output_tensors) < 2:
             raise ValueError(
-                "KV260 XModel must expose image_scores and score_map outputs"
+                "KV260 XModel must expose image_scores and score_map outputs. "
+                "A backbone-only XModel is not a complete PaDiM/PatchCore model."
             )
-        self.output_names = [tensor.name for tensor in self.output_tensors]
+
+        self.input_tensor = self.input_tensors[0]
+        self.output_names = [getattr(tensor, "name", "") for tensor in self.output_tensors]
         self.input_shape = tuple(int(value) for value in self.input_tensor.dims)
 
     @staticmethod
@@ -81,33 +111,64 @@ class KV260Backend(InferenceBackend):
             )
         )
         batch = resized[None]
-        if len(self.input_shape) == 4 and self.input_shape[1] == 3:
+        if len(self.input_shape) == 4 and self.input_shape[-1] == 3:
+            # Vitis AI DPU tensors are normally NHWC.
+            pass
+        elif len(self.input_shape) == 4 and self.input_shape[1] == 3:
             batch = np.transpose(batch, (0, 3, 1, 2))
-        if np.issubdtype(self.input_tensor.dtype, np.floating):
+        if np.issubdtype(np.dtype(self.input_tensor.dtype), np.floating):
             return (batch.astype(np.float32) / 255.0).astype(self.input_tensor.dtype)
         return batch.astype(self.input_tensor.dtype)
 
+    @staticmethod
+    def _copy_to_tensor_buffer(buffer: Any, data: np.ndarray) -> None:
+        """Copy a NumPy array into a VART TensorBuffer."""
+        target = np.asarray(buffer)
+        if target.shape != data.shape:
+            data = data.reshape(target.shape)
+        np.copyto(target, data, casting="unsafe")
+
     def predict(self, batch: Any) -> ScoresMaps:
-        """Run one image through VART and return anomaly scores and maps.
-
-        Args:
-            batch: An image path, PIL image, or RGB NumPy array.
-
-        Returns:
-            A tuple ``(image_scores, score_maps)`` as NumPy arrays.
-        """
+        """Run one image through the complete XModel graph."""
         input_data = self._preprocess(batch)
-        outputs = [
-            np.empty(tuple(int(value) for value in tensor.dims), dtype=tensor.dtype)
-            for tensor in self.output_tensors
-        ]
-        job_id = self.runner.execute_async([input_data], outputs)
-        self.runner.wait(job_id)
+
+        if self._graph_runner:
+            input_buffers = self.runner.get_inputs()
+            output_buffers = self.runner.get_outputs()
+            self._copy_to_tensor_buffer(input_buffers[0], input_data)
+            for buffer in input_buffers:
+                buffer.sync_for_write(
+                    0,
+                    buffer.get_tensor().get_data_size()
+                    // buffer.get_tensor().dims[0],
+                )
+            job_id, status = self.runner.execute_async(input_buffers, output_buffers)
+            if status != 0:
+                raise RuntimeError(f"KV260 GraphRunner execution failed: {status}")
+            status = self.runner.wait(job_id)
+            if status != 0:
+                raise RuntimeError(f"KV260 GraphRunner wait failed: {status}")
+            for buffer in output_buffers:
+                buffer.sync_for_read(
+                    0,
+                    buffer.get_tensor().get_data_size()
+                    // buffer.get_tensor().dims[0],
+                )
+            outputs = [np.asarray(buffer).copy() for buffer in output_buffers]
+        else:
+            outputs = [
+                np.empty(tuple(int(value) for value in tensor.dims), dtype=tensor.dtype)
+                for tensor in self.output_tensors
+            ]
+            result = self.runner.execute_async([input_data], outputs)
+            job_id = result[0] if isinstance(result, tuple) else result
+            self.runner.wait(job_id)
+
         image_index = next(
             (
                 index
                 for index, name in enumerate(self.output_names)
-                if "image_score" in name
+                if "image_score" in name or "score" in name
             ),
             0,
         )
@@ -125,7 +186,7 @@ class KV260Backend(InferenceBackend):
         )
 
     def close(self) -> None:
-        """Release the VART runner and allow its resources to be reclaimed."""
+        """Release the VART/GraphRunner resources."""
         self.runner = None
 
 

--- a/docs/kv260_xmodel.md
+++ b/docs/kv260_xmodel.md
@@ -1,0 +1,407 @@
+# AnomaVision → KV260 XModel
+
+This guide explains how to quantize **AnomaVision PaDiM and PatchCore** with **Vitis AI 3.5**, generate an INT8 XModel, validate it, and compile it for the **AMD/Xilinx Kria KV260 DPU**.
+
+The workflow is intended for a Linux environment with the Vitis AI tools available.
+
+## 1. Workflow
+
+The deployment flow is:
+
+```text
+AnomaVision PyTorch model
+        ↓
+Vitis AI INT8 calibration
+        ↓
+INT8 XModel
+        ↓
+XModel validation
+        ↓
+vai_c_xir + KV260 arch.json
+        ↓
+KV260 DPU compiled model
+```
+
+Both PaDiM and PatchCore use the same basic workflow.
+
+## 2. Activate Vitis AI
+
+Activate the Vitis AI PyTorch environment:
+
+```bash
+conda activate vitis-ai-pytorch
+```
+
+Check that the compiler is available:
+
+```bash
+vai_c_xir -h
+```
+
+You should be able to run the command without a `command not found` error.
+
+## 3. Go to AnomaVision
+
+```bash
+cd /workspace/AnomaVision
+```
+
+Check the repository:
+
+```bash
+ls
+```
+
+The KV260 quantization scripts are:
+
+```text
+quantize_padim_kv260.py
+quantize_patchcore_kv260.py
+```
+
+## 4. Prepare calibration images
+
+Use **normal/good training images** for INT8 calibration.
+
+For the MVTec bottle example:
+
+```text
+/workspace/dataset/bottle/train/good
+```
+
+Check the directory:
+
+```bash
+ls /workspace/dataset/bottle/train/good | head
+```
+
+The calibration set should contain representative normal images. It should normally come from the same type of data used to train the anomaly detector.
+
+---
+
+# PaDiM → KV260 XModel
+
+## 5. PaDiM model
+
+The example PaDiM model is:
+
+```text
+distributions/padim/bottle/anomav_exp/model.pt
+```
+
+The output directory used below is:
+
+```text
+compiled_padim_kv260
+```
+
+## 6. Run PaDiM INT8 calibration
+
+Run the calibration phase:
+
+```bash
+python quantize_padim_kv260.py \
+  --model distributions/padim/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_padim_kv260 \
+  --quant_mode calib
+```
+
+The calibration phase collects activation statistics and prepares the quantization configuration.
+
+Check the generated files:
+
+```bash
+find compiled_padim_kv260 -maxdepth 2 -type f
+```
+
+## 7. Generate the PaDiM INT8 XModel
+
+Run the script in test mode:
+
+```bash
+python quantize_padim_kv260.py \
+  --model distributions/padim/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_padim_kv260 \
+  --quant_mode test
+```
+
+The important output is:
+
+```text
+compiled_padim_kv260/PadimKV260_int.xmodel
+```
+
+## 8. Validate the PaDiM XModel
+
+Check that the XModel exists:
+
+```bash
+ls -lh compiled_padim_kv260/*.xmodel
+```
+
+You can also inspect it with XIR:
+
+```bash
+python -c "import xir; g=xir.Graph.deserialize('compiled_padim_kv260/PadimKV260_int.xmodel'); print('XModel OK:', g.get_name()); print('Ops:', len(g.get_ops()))"
+```
+
+If the graph loads successfully, the generated XModel is readable by XIR.
+
+## 9. Compile PaDiM for KV260
+
+Use the KV260 DPU architecture file:
+
+```bash
+vai_c_xir \
+  -x compiled_padim_kv260/PadimKV260_int.xmodel \
+  -a /opt/vitis_ai/compiler/arch/DPUCZDX8G/KV260/arch.json \
+  -o compiled_padim_kv260/compiled \
+  -n PadimKV260
+```
+
+The compiled output is placed under:
+
+```text
+compiled_padim_kv260/compiled
+```
+
+---
+
+# PatchCore → KV260 XModel
+
+## 10. PatchCore model
+
+The example PatchCore model is:
+
+```text
+distributions/patchcore/bottle/anomav_exp/model.pt
+```
+
+Calibration images are the same normal training images:
+
+```text
+/workspace/dataset/bottle/train/good
+```
+
+## 11. Run PatchCore INT8 calibration
+
+```bash
+python quantize_patchcore_kv260.py \
+  --model distributions/patchcore/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_patchcore_kv260 \
+  --quant_mode calib
+```
+
+Check the output:
+
+```bash
+find compiled_patchcore_kv260 -maxdepth 2 -type f
+```
+
+## 12. Generate the PatchCore INT8 XModel
+
+Run test mode:
+
+```bash
+python quantize_patchcore_kv260.py \
+  --model distributions/patchcore/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_patchcore_kv260 \
+  --quant_mode test
+```
+
+The important output is:
+
+```text
+compiled_patchcore_kv260/PatchCoreKV260_int.xmodel
+```
+
+## 13. Validate the PatchCore XModel
+
+```bash
+ls -lh compiled_patchcore_kv260/*.xmodel
+```
+
+Inspect it with XIR:
+
+```bash
+python -c "import xir; g=xir.Graph.deserialize('compiled_patchcore_kv260/PatchCoreKV260_int.xmodel'); print('XModel OK:', g.get_name()); print('Ops:', len(g.get_ops()))"
+```
+
+A successful graph load confirms that the XModel can be deserialized by XIR.
+
+## 14. Compile PatchCore for KV260
+
+```bash
+vai_c_xir \
+  -x compiled_patchcore_kv260/PatchCoreKV260_int.xmodel \
+  -a /opt/vitis_ai/compiler/arch/DPUCZDX8G/KV260/arch.json \
+  -o compiled_patchcore_kv260/compiled \
+  -n PatchCoreKV260
+```
+
+The compiled output is placed under:
+
+```text
+compiled_patchcore_kv260/compiled
+```
+
+---
+
+# Expected output
+
+After completing both workflows, the directories should contain the generated INT8 XModels and compiler output.
+
+```text
+compiled_padim_kv260/
+├── PadimKV260_int.xmodel
+└── compiled/
+    └── ...
+
+compiled_patchcore_kv260/
+├── PatchCoreKV260_int.xmodel
+└── compiled/
+    └── ...
+```
+
+The exact files inside `compiled/` can vary with the Vitis AI compiler output.
+
+## 15. Important notes
+
+### Calibration vs. test mode
+
+Use the two modes in this order:
+
+```text
+calib → test → vai_c_xir
+```
+
+Do not skip calibration when generating a calibrated INT8 model.
+
+### Calibration data
+
+Use representative **normal/good images**. Poor calibration data can reduce INT8 accuracy.
+
+### KV260 architecture
+
+The compiler must use the architecture file for the target KV260 DPU:
+
+```text
+/opt/vitis_ai/compiler/arch/DPUCZDX8G/KV260/arch.json
+```
+
+Do not use an architecture file for another DPU target.
+
+### Linux/Vitis AI requirement
+
+The XModel workflow depends on Vitis AI tooling and is intended to run in the supported Linux/Vitis AI environment. Windows-only execution is not expected to provide the required Vitis AI compiler commands.
+
+### XModel generation vs. device validation
+
+A successfully generated and compiled XModel does **not by itself prove end-to-end KV260 application correctness**. The final step is to deploy the compiled model on the KV260 and validate preprocessing, tensor layout, postprocessing, anomaly scores, and latency on the target hardware.
+
+## 16. Quick reference
+
+### PaDiM
+
+```bash
+# Calibration
+python quantize_padim_kv260.py \
+  --model distributions/padim/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_padim_kv260 \
+  --quant_mode calib
+
+# XModel generation
+python quantize_padim_kv260.py \
+  --model distributions/padim/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_padim_kv260 \
+  --quant_mode test
+
+# KV260 compilation
+vai_c_xir \
+  -x compiled_padim_kv260/PadimKV260_int.xmodel \
+  -a /opt/vitis_ai/compiler/arch/DPUCZDX8G/KV260/arch.json \
+  -o compiled_padim_kv260/compiled \
+  -n PadimKV260
+```
+
+### PatchCore
+
+```bash
+# Calibration
+python quantize_patchcore_kv260.py \
+  --model distributions/patchcore/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_patchcore_kv260 \
+  --quant_mode calib
+
+# XModel generation
+python quantize_patchcore_kv260.py \
+  --model distributions/patchcore/bottle/anomav_exp/model.pt \
+  --calibration-dir /workspace/dataset/bottle/train/good \
+  --output-dir compiled_patchcore_kv260 \
+  --quant_mode test
+
+# KV260 compilation
+vai_c_xir \
+  -x compiled_patchcore_kv260/PatchCoreKV260_int.xmodel \
+  -a /opt/vitis_ai/compiler/arch/DPUCZDX8G/KV260/arch.json \
+  -o compiled_patchcore_kv260/compiled \
+  -n PatchCoreKV260
+```
+
+## 17. Troubleshooting
+
+### `vai_c_xir: command not found`
+
+The Vitis AI environment is probably not activated. Check:
+
+```bash
+conda activate vitis-ai-pytorch
+vai_c_xir -h
+```
+
+### `arch.json` not found
+
+Verify the KV260 architecture path:
+
+```bash
+ls -lh /opt/vitis_ai/compiler/arch/DPUCZDX8G/KV260/arch.json
+```
+
+If the file is not present, use the architecture path provided by your Vitis AI installation, but make sure it corresponds to the KV260 DPU.
+
+### XModel does not exist after test mode
+
+Check the script output and the contents of the selected output directory:
+
+```bash
+find compiled_padim_kv260 -maxdepth 2 -type f
+```
+
+or:
+
+```bash
+find compiled_patchcore_kv260 -maxdepth 2 -type f
+```
+
+Also confirm that the calibration phase completed successfully before running test mode.
+
+### XModel cannot be deserialized
+
+Check that the XModel was generated by the Vitis AI tooling in the active environment and that `xir` is available:
+
+```bash
+python -c "import xir; print('XIR OK')"
+```
+
+## 18. Final deployment step
+
+Once `vai_c_xir` completes successfully, copy the compiled deployment artifacts to the KV260 application environment and run the corresponding AnomaVision inference pipeline.
+
+For production deployment, validate the complete pipeline on the actual KV260 hardware rather than relying only on host-side XModel compilation.


### PR DESCRIPTION
## 🔗 Related Issue

Fixes #

## 📝 Description

* Added **KV260 XModel support** for **PaDiM and PatchCore**.
* Added KV260 INT8 quantization and XModel compilation workflows.
* Updated inference backend and documentation with quantization guides.
* Added detailed documentation for running PaDiM and PatchCore on KV260.
* XModel compilation validated successfully with Vitis AI 3.5.
* **On-device inference/accuracy validation is pending** because KV260 hardware is currently unavailable.

## 🔄 Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [x] 🚀 New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change
* [x] 📖 Documentation update
* [ ] 🏗️ Infrastructure / CI/CD update

## 🧪 Hardware & Matrix Testing

**Vitis AI / KV260:**

* [x] PaDiM INT8 calibration
* [x] PaDiM XModel generation
* [x] PaDiM KV260 compilation
* [x] PatchCore XModel generation
* [x] KV260 XModel graph/subgraph inspection
* [ ] KV260 on-device inference — **hardware unavailable**
* [ ] ONNX vs XModel accuracy comparison — **pending hardware**

**Host OS used for testing:**

* [x] Linux / Ubuntu
* [ ] Windows
* [ ] macOS

## ✅ Developer Checklist

* [x] Code follows the project style guidelines.
* [ ] `uv run pytest` — not run in the Vitis AI environment.
* [x] No new Python dependencies added.
* [x] Documentation updated.
* [x] Quantization and compilation workflow manually verified.

## 📸 Screenshots / Visual Proof

Vitis AI successfully compiled the PaDiM model for:

```text
DPUCZDX8G_ISA1_B4096
KV260
```

Generated:

```text
PadimKV260.xmodel
```

On-device validation remains pending due to unavailable KV260 hardware.
