### PR TITLE
adds and improves KV260 deployment support for PaDiM and PatchCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,40 +5,39 @@
 </p>
 
 <p align="center">
-  <strong>Production-oriented visual anomaly detection from normal images.</strong>
+  <strong>Simple visual anomaly detection from normal images.</strong>
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/anomavision/"><img src="https://img.shields.io/pypi/v/anomavision?label=PyPI&color=blue" alt="PyPI version"/></a>
-  <a href="https://pypi.org/project/anomavision/"><img src="https://img.shields.io/pypi/dm/anomavision?color=blue" alt="PyPI downloads"/></a>
-  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.10--3.12-blue" alt="Python 3.10 to 3.12"/></a>
-  <a href="https://pytorch.org/"><img src="https://img.shields.io/badge/PyTorch-2.0%2B-red" alt="PyTorch 2.0 or newer"/></a>
-  <a href="https://onnx.ai/"><img src="https://img.shields.io/badge/ONNX-Export%20Ready-orange" alt="ONNX export ready"/></a>
-  <a href="https://developer.nvidia.com/tensorrt"><img src="https://img.shields.io/badge/TensorRT-Supported-76b900" alt="TensorRT supported"/></a>
-  <a href="https://docs.openvino.ai/"><img src="https://img.shields.io/badge/OpenVINO-Supported-0071C5" alt="OpenVINO supported"/></a>
+  <a href="https://pypi.org/project/anomavision/"><img src="https://img.shields.io/pypi/v/anomavision?label=PyPI" alt="PyPI version"/></a>
   <a href="https://github.com/DeepKnowledge1/AnomaVision/actions/workflows/ci.yml"><img src="https://github.com/DeepKnowledge1/AnomaVision/actions/workflows/ci.yml/badge.svg" alt="CI status"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green" alt="MIT license"/></a>
 </p>
 
-AnomaVision supports **PaDiM** and lightweight **PatchCore**, image-level scores, pixel-level maps, and deployment exports.
+AnomaVision is a computer vision project for finding **defects and unusual patterns** in images.
+
+It supports two anomaly detection methods:
+
+- **PaDiM** — a simple and fast baseline.
+- **PatchCore** — a lightweight memory-based method.
+
+You only need **normal (`good`) images** to train the anomaly detector.
 
 <p align="center">
   <a href="https://huggingface.co/spaces/DeepKnowledge1/mvtec-anomaly-detection"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl-dark.svg" alt="Open the AnomaVision live demo"/></a>
 </p>
 
-**Try it first:** [live demo](https://huggingface.co/spaces/DeepKnowledge1/mvtec-anomaly-detection) · [five-minute CPU quickstart](docs/quickstart.md) · [runnable examples](examples/README.md) · [reproducible benchmark](docs/benchmark.md)
+**New here?** Start with the [five-minute quickstart](docs/quickstart.md).
 
-## Why use it?
+## What can AnomaVision do?
 
-- Train with normal images only; anomaly labels are not required for training.
-- Use **PaDiM** for the default fast baseline or **PatchCore** for a compact nearest-neighbor memory bank.
-- Run inference through PyTorch, ONNX Runtime, OpenVINO, or native TensorRT.
-- Export FP16 or calibrated INT8 TensorRT engines for NVIDIA production deployments.
-- **Export and compile PaDiM and PatchCore to Vitis AI XModel for the AMD/Xilinx Kria KV260.**
+- Train anomaly detection models using normal images.
+- Detect image-level anomalies.
+- Create anomaly heatmaps showing where the problem is.
+- Export models to **ONNX, OpenVINO, and TensorRT**.
+- Export and compile **PaDiM and PatchCore to XModel for the AMD/Xilinx Kria KV260**.
 
-Benchmark results and reproduction details are documented in [`docs/benchmark.md`](docs/benchmark.md). Treat benchmark numbers as workload-specific, and reproduce them on your own hardware before making production claims.
-
-## Quickstart
+## Quick start
 
 ### 1. Install
 
@@ -47,195 +46,97 @@ pip install uv
 uv pip install "anomavision[cpu]"
 ```
 
-For NVIDIA GPUs, choose the matching extra such as `anomavision[cu121]`. Source installation and environment setup are described in [`docs/installation.md`](docs/installation.md). For the shortest CPU path, use the copy-ready [`examples/quickstart_cpu.yml`](examples/quickstart_cpu.yml) configuration and follow [`docs/quickstart.md`](docs/quickstart.md).
+For other environments, see [Installation](docs/installation.md).
 
-### 2. Prepare data
+### 2. Prepare your images
 
-Use an MVTec-style directory. Training uses only the `good` images:
+Use a simple MVTec-style folder structure:
 
 ```text
 dataset/
 └── bottle/
-    ├── train/good/
+    ├── train/
+    │   └── good/
     └── test/
         ├── good/
         └── scratch/
 ```
 
+Training uses the **good** images. Test images can contain defects.
+
 ### 3. Train
 
-Before running the command, open `config.yml` and set `dataset_path` to the folder that contains your class folder, for example `./dataset`. Keep `class_name: bottle` if your data is stored under `./dataset/bottle/`.
+Create or edit `config.yml` and point `dataset_path` to your dataset.
+
+Then run:
 
 ```bash
 anomavision train --config config.yml
 ```
 
-The default configuration trains PaDiM. To use the ultra-light PatchCore path, change these values in `config.yml`:
+PaDiM is the default model. For PatchCore, set `algorithm: patchcore` in the configuration.
 
-```yaml
-algorithm: patchcore
-layer_indices: [0]
-coreset_ratio: 0.02
-max_memory_patches: 2048
-patch_grid: 14
-```
-
-The model and compact deployment artifact are saved under `model_data_path`.
-
-### 4. Detect and evaluate
+### 4. Detect
 
 ```bash
 anomavision detect --config config.yml --img_path ./dataset/bottle/test
-anomavision eval --config config.yml
 ```
 
 ### 5. Export
 
+For a portable model, ONNX is a good place to start:
+
 ```bash
-# Portable ONNX export
 anomavision export --config config.yml --format onnx
-
-# Native TensorRT FP16 export
-anomavision export --config config.yml --format tensorrt \
-  --device cuda --tensorrt-precision fp16
-
-# Native TensorRT calibrated INT8 export
-anomavision export --config config.yml --format tensorrt \
-  --device cuda --tensorrt-precision int8 \
-  --calib-dir ./dataset/bottle/train/good --calib-samples 100
 ```
 
-Every command provides help:
+For more export options, see [Export and deployment](docs/production_deployment.md).
 
-```bash
-anomavision --help
-anomavision train --help
-anomavision export --help
+## KV260 support
+
+AnomaVision also supports a **Vitis AI workflow for PaDiM and PatchCore on the AMD/Xilinx Kria KV260**.
+
+The workflow is:
+
+```text
+PyTorch → INT8 quantization → XModel → KV260 DPU compilation
 ```
 
-## KV260 XModel deployment
+Both PaDiM and PatchCore currently compile with **1 DPU subgraph** in the KV260 compiler.
 
-AnomaVision also provides a Vitis AI workflow for deploying **PaDiM** and **PatchCore** on the **AMD/Xilinx Kria KV260** DPU.
+The complete setup and commands are in:
 
-The KV260 workflow is:
+**[KV260 XModel Guide](docs/kv260_xmodel.md)**
 
-**PyTorch model → Vitis AI INT8 quantization → XModel → KV260 DPU compilation**
+> XModel compilation has been validated in the Vitis AI environment. Final on-device KV260 validation requires the physical hardware.
 
-The detailed, copy-ready guide is available in [`docs/kv260_xmodel.md`](docs/kv260_xmodel.md).
+## Which model should I try?
 
-The guide covers:
+| Model | Good starting point |
+|---|---|
+| **PaDiM** | Simple and fast baseline |
+| **PatchCore** | Lightweight memory-based anomaly detection |
 
-- Vitis AI 3.5 environment setup
-- PaDiM INT8 calibration and test mode
-- PatchCore INT8 calibration and test mode
-- XModel validation
-- KV260 DPU compilation with `vai_c_xir`
-- Expected output files and troubleshooting notes
-
-### PaDiM quick example
-
-```bash
-python quantize_padim_kv260.py \
-  --model distributions/padim/bottle/anomav_exp/model.pt \
-  --calibration-dir /workspace/dataset/bottle/train/good \
-  --output-dir compiled_padim_kv260 \
-  --quant_mode calib
-
-python quantize_padim_kv260.py \
-  --model distributions/padim/bottle/anomav_exp/model.pt \
-  --calibration-dir /workspace/dataset/bottle/train/good \
-  --output-dir compiled_padim_kv260 \
-  --quant_mode test
-
-vai_c_xir \
-  -x compiled_padim_kv260/PadimKV260_int.xmodel \
-  -a /opt/vitis_ai/compiler/arch/DPUCZDX8G/KV260/arch.json \
-  -o compiled_padim_kv260/compiled \
-  -n PadimKV260
-```
-
-### PatchCore quick example
-
-```bash
-python quantize_patchcore_kv260.py \
-  --model distributions/patchcore/bottle/anomav_exp/model.pt \
-  --calibration-dir /workspace/dataset/bottle/train/good \
-  --output-dir compiled_patchcore_kv260 \
-  --quant_mode calib
-
-python quantize_patchcore_kv260.py \
-  --model distributions/patchcore/bottle/anomav_exp/model.pt \
-  --calibration-dir /workspace/dataset/bottle/train/good \
-  --output-dir compiled_patchcore_kv260 \
-  --quant_mode test
-
-vai_c_xir \
-  -x compiled_patchcore_kv260/PatchCoreKV260_int.xmodel \
-  -a /opt/vitis_ai/compiler/arch/DPUCZDX8G/KV260/arch.json \
-  -o compiled_patchcore_kv260/compiled \
-  -n PatchCoreKV260
-```
-
-> **Note:** KV260 XModel generation and compilation are intended for a Linux/Vitis AI environment. The final on-device KV260 validation is a separate step from XModel generation and compiler validation.
-
-## Production Autopilot
-
-**Production Autopilot is the easiest way to move from two trained models to one deployable choice.** It compares PaDiM and ultra-light PatchCore on the same labeled test split, calibrates a separate threshold for each, profiles median and P95 latency on your hardware, checks localization health, and packages the selected artifact with a self-contained HTML dashboard.
-
-Train both candidate models first, then run the complete labeled split on CPU:
-
-```bash
-anomavision autopilot \
-  --config config.yml \
-  --padim_model ./distributions/padim/bottle/anomav_exp/model.pt \
-  --patchcore_model ./distributions/patchcore/bottle/anomav_exp/model.pt \
-  --device cpu \
-  --validation_split 1.0 \
-  --target_latency_ms 50 \
-  --output_dir ./production_package
-```
-
-Open `production_package/production_autopilot_report.html` to see the selected model, AUROC, calibrated threshold, localization diagnostics, memory, median latency, P95 latency, and deployment recommendation. The package also contains `deployment_manifest.json`, `localization_report.md`, and the selected model artifact. See [`docs/production_deployment.md`](docs/production_deployment.md) for GPU, TensorRT, INT8, and packaging details.
-
-## Visual overview
-
-The same pipeline supports compact edge inference and spatial anomaly localization. In each result strip, the panels show the **input image**, the **detected boundary**, and the **anomaly heatmap** from left to right.
-
-### PaDiM: distribution-based heatmap
-
-PaDiM models the feature distribution of normal images. Its heatmap is typically smoother and emphasizes regions that differ from that learned distribution.
-
-![PaDiM input, boundary, and heatmap example](notebooks/example_images/padim_example_image.png)
-
-### Ultra-light PatchCore: nearest-patch heatmap
-
-PatchCore compares image patches with a compact normal-feature memory bank. Its heatmap can show more local texture and sharper nearest-patch differences while using bounded memory for production inference.
-
-![PatchCore input, boundary, and heatmap example](notebooks/example_images/patchcore_example_image.png)
-
-## Choosing a model
-
-| Model | Best starting point | Memory use | Production note |
-|---|---|---:|---|
-| PaDiM | Fast, simple baseline | Low | Recommended first experiment |
-| Lightweight PatchCore | Lower-memory nearest-patch baseline | Very low by default | Use `coreset_ratio`, `max_memory_patches`, and `patch_grid` to control latency |
+If you are new to anomaly detection, **start with PaDiM**.
 
 ## Documentation
 
 | Topic | Guide |
 |---|---|
+| Quick start | [`docs/quickstart.md`](docs/quickstart.md) |
 | Installation | [`docs/installation.md`](docs/installation.md) |
-| Five-minute workflow | [`docs/quickstart.md`](docs/quickstart.md) |
 | CLI and configuration | [`docs/cli.md`](docs/cli.md), [`docs/config.md`](docs/config.md) |
 | Python API | [`docs/api.md`](docs/api.md) |
-| PatchCore and TensorRT deployment | [`docs/production_deployment.md`](docs/production_deployment.md) |
-| **KV260 PaDiM/PatchCore XModel** | [`docs/kv260_xmodel.md`](docs/kv260_xmodel.md) |
-| Runnable CPU, PatchCore, and TensorRT examples | [`examples/README.md`](examples/README.md) |
-| Benchmark methodology | [`docs/benchmark.md`](docs/benchmark.md) |
+| KV260 / XModel | [`docs/kv260_xmodel.md`](docs/kv260_xmodel.md) |
+| Production deployment | [`docs/production_deployment.md`](docs/production_deployment.md) |
+| Benchmarks | [`docs/benchmark.md`](docs/benchmark.md) |
 | Troubleshooting | [`docs/troubleshooting.md`](docs/troubleshooting.md) |
+| Examples | [`examples/README.md`](examples/README.md) |
 | Contributing | [`docs/contributing.md`](docs/contributing.md) |
 
-## Python API
+## Python example
+
+You can also use AnomaVision directly from Python:
 
 ```python
 import torch
@@ -247,16 +148,18 @@ train_loader = DataLoader(train_set, batch_size=16, shuffle=False)
 
 model = anomavision.Padim(backbone="resnet18", device=torch.device("cpu"))
 model.fit(train_loader)
+
 batch = next(iter(train_loader))
 if isinstance(batch, (tuple, list)):
     batch = batch[0]
+
 scores, maps = model.predict(batch)
 ```
 
-## Community and adoption
-
-The most useful path to adoption is a small, reproducible example rather than more README text: publish one benchmark script, one production export example, a model card with hardware and preprocessing details, and a short comparison against Anomalib. Invite users to reproduce the result, report failures, and contribute adapters for their own datasets. See [`docs/production_deployment.md`](docs/production_deployment.md) for the project’s recommended release checklist.
-
 ## License
 
-AnomaVision is released under the MIT License. See [`LICENSE`](LICENSE).
+AnomaVision is released under the **MIT License**. See [`LICENSE`](LICENSE).
+
+## Questions and contributions
+
+Found a problem or have an idea? Feel free to open an issue or contribute to the project.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/anomavision/"><img src="https://img.shields.io/pypi/v/anomavision?label=PyPI" alt="PyPI version"/></a>
+  <a href="https://pypi.org/project/anomavision/"><img src="https://img.shields.io/pypi/v/anomavision?label=PyPI&color=blue" alt="PyPI version"/></a>
+  <a href="https://pypi.org/project/anomavision/"><img src="https://img.shields.io/pypi/dm/anomavision?color=blue" alt="PyPI downloads"/></a>
+  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.10--3.12-blue" alt="Python 3.10 to 3.12"/></a>
+  <a href="https://pytorch.org/"><img src="https://img.shields.io/badge/PyTorch-2.0%2B-red" alt="PyTorch 2.0 or newer"/></a>
+  <a href="https://onnx.ai/"><img src="https://img.shields.io/badge/ONNX-Export%20Ready-orange" alt="ONNX export ready"/></a>
+  <a href="https://developer.nvidia.com/tensorrt"><img src="https://img.shields.io/badge/TensorRT-Supported-76b900" alt="TensorRT supported"/></a>
+  <a href="https://docs.openvino.ai/"><img src="https://img.shields.io/badge/OpenVINO-Supported-0071C5" alt="OpenVINO supported"/></a>
   <a href="https://github.com/DeepKnowledge1/AnomaVision/actions/workflows/ci.yml"><img src="https://github.com/DeepKnowledge1/AnomaVision/actions/workflows/ci.yml/badge.svg" alt="CI status"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green" alt="MIT license"/></a>
   <a href="docs/kv260_xmodel.md"><img src="https://img.shields.io/badge/KV260-DPU-blue" alt="KV260 DPU support"/></a>
@@ -42,10 +48,35 @@ You only need **normal (`good`) images** to train the anomaly detector.
 
 ### 1. Install
 
+#### Option A — From Source (development)
+
 ```bash
-pip install uv
-uv pip install "anomavision[cpu]"
+git clone https://github.com/DeepKnowledge1/AnomaVision.git
+cd AnomaVision
+
+# Create and activate a virtual environment
+uv venv --python 3.11 .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\Activate.ps1
+
+# Install with your hardware extra
+uv sync --extra cpu              # CPU
+uv sync --extra cu121            # CUDA 12.1
 ```
+
+---
+
+#### Option B — From PyPI (production / quick start)
+
+```bash
+# CPU  ·  Mac, CI runners, edge devices
+uv pip install "anomavision[cpu]"
+
+# NVIDIA GPU  ·  pick your CUDA version
+uv pip install "anomavision[cu118]"   # CUDA 11.8
+uv pip install "anomavision[cu121]"   # CUDA 12.1
+uv pip install "anomavision[cu124]"   # CUDA 12.4
+```
+
 
 For other environments, see [Installation](docs/installation.md).
 
@@ -56,11 +87,17 @@ Use a simple MVTec-style folder structure:
 ```text
 dataset/
 └── bottle/
-    ├── train/
+    ├── ground_truth/
+    │   ├── broken_large/
+    │   ├── broken_small/
+    │   └── contamination/
+    ├── test/
+    │   ├── broken_large/
+    │   ├── broken_small/
+    │   ├── contamination/
     │   └── good/
-    └── test/
-        ├── good/
-        └── scratch/
+    └── train/
+        └── good/
 ```
 
 Training uses the **good** images. Test images can contain defects.
@@ -111,14 +148,26 @@ The complete setup and commands are in:
 
 > XModel compilation has been validated in the Vitis AI environment. Final on-device KV260 validation requires the physical hardware.
 
-## Which model should I try?
 
-| Model | Good starting point |
-|---|---|
-| **PaDiM** | Simple and fast baseline |
-| **PatchCore** | Lightweight memory-based anomaly detection |
+## Production Autopilot
 
-If you are new to anomaly detection, **start with PaDiM**.
+**Production Autopilot is the easiest way to move from two trained models to one deployable choice.** It compares PaDiM and ultra-light PatchCore on the same labeled test split, calibrates a separate threshold for each, profiles median and P95 latency on your hardware, checks localization health, and packages the selected artifact with a self-contained HTML dashboard.
+
+Train both candidate models first, then run the complete labeled split on CPU:
+
+```bash
+anomavision autopilot \
+  --config config.yml \
+  --padim_model ./distributions/padim/bottle/anomav_exp/model.pt \
+  --patchcore_model ./distributions/patchcore/bottle/anomav_exp/model.pt \
+  --device cpu \
+  --validation_split 1.0 \
+  --target_latency_ms 50 \
+  --output_dir ./production_package
+```
+
+Open `production_package/production_autopilot_report.html` to see the selected model, AUROC, calibrated threshold, localization diagnostics, memory, median latency, P95 latency, and deployment recommendation. The package also contains `deployment_manifest.json`, `localization_report.md`, and the selected model artifact. See [`docs/production_deployment.md`](docs/production_deployment.md) for GPU, TensorRT, INT8, and packaging details.
+
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://pypi.org/project/anomavision/"><img src="https://img.shields.io/pypi/v/anomavision?label=PyPI" alt="PyPI version"/></a>
   <a href="https://github.com/DeepKnowledge1/AnomaVision/actions/workflows/ci.yml"><img src="https://github.com/DeepKnowledge1/AnomaVision/actions/workflows/ci.yml/badge.svg" alt="CI status"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green" alt="MIT license"/></a>
+  <a href="docs/kv260_xmodel.md"><img src="https://img.shields.io/badge/KV260-DPU-blue" alt="KV260 DPU support"/></a>
 </p>
 
 AnomaVision is a computer vision project for finding **defects and unusual patterns** in images.

--- a/anomavision/algorithm/common/mahalanobis.py
+++ b/anomavision/algorithm/common/mahalanobis.py
@@ -144,13 +144,13 @@ class MahalanobisDistance(nn.Module):
             # (B,N,1,D) @ (1,N,D,D) -> (B,N,1,D)
             left = torch.matmul(delta.unsqueeze(2), self._cov_inv_flat.unsqueeze(0))
             # (B,N,1,D) @ (B,N,D,1) -> (B,N,1,1) -> (B,N)
-            
-            # dist2 = torch.matmul(left, delta.unsqueeze(-1)).squeeze(-1).squeeze(-1)
-            # distances = dist2.clamp_min_(0).sqrt_().view(B, width, height)
+
+            dist2 = torch.matmul(
+                left, delta.unsqueeze(-1)
+            ).squeeze(-1).squeeze(-1)
 
             dist2 = torch.clamp(dist2, min=0.0)
             distances = torch.sqrt(dist2).reshape(B, width, height)
-
             return distances
 
         # === Chunked path (low peak RAM; fixes broadcasting by expanding over B) ===

--- a/anomavision/algorithm/common/mahalanobis.py
+++ b/anomavision/algorithm/common/mahalanobis.py
@@ -144,8 +144,13 @@ class MahalanobisDistance(nn.Module):
             # (B,N,1,D) @ (1,N,D,D) -> (B,N,1,D)
             left = torch.matmul(delta.unsqueeze(2), self._cov_inv_flat.unsqueeze(0))
             # (B,N,1,D) @ (B,N,D,1) -> (B,N,1,1) -> (B,N)
-            dist2 = torch.matmul(left, delta.unsqueeze(-1)).squeeze(-1).squeeze(-1)
-            distances = dist2.clamp_min_(0).sqrt_().view(B, width, height)
+            
+            # dist2 = torch.matmul(left, delta.unsqueeze(-1)).squeeze(-1).squeeze(-1)
+            # distances = dist2.clamp_min_(0).sqrt_().view(B, width, height)
+
+            dist2 = torch.clamp(dist2, min=0.0)
+            distances = torch.sqrt(dist2).reshape(B, width, height)
+
             return distances
 
         # === Chunked path (low peak RAM; fixes broadcasting by expanding over B) ===

--- a/anomavision/algorithm/common/mahalanobis.py
+++ b/anomavision/algorithm/common/mahalanobis.py
@@ -145,9 +145,7 @@ class MahalanobisDistance(nn.Module):
             left = torch.matmul(delta.unsqueeze(2), self._cov_inv_flat.unsqueeze(0))
             # (B,N,1,D) @ (B,N,D,1) -> (B,N,1,1) -> (B,N)
 
-            dist2 = torch.matmul(
-                left, delta.unsqueeze(-1)
-            ).squeeze(-1).squeeze(-1)
+            dist2 = torch.matmul(left, delta.unsqueeze(-1)).squeeze(-1).squeeze(-1)
 
             dist2 = torch.clamp(dist2, min=0.0)
             distances = torch.sqrt(dist2).reshape(B, width, height)

--- a/anomavision/quantize/model/backends/xmodel/padim.py
+++ b/anomavision/quantize/model/backends/xmodel/padim.py
@@ -1,25 +1,48 @@
-"""Minimal PaDiM backbone graph for AMD/Xilinx KV260."""
+"""PaDiM graph for AMD/Xilinx KV260."""
 
 from __future__ import annotations
 
 import torch
 import torch.nn as nn
 
+from .....algorithm.common.mahalanobis import MahalanobisDistance
 
 class PadimKV260(nn.Module):
-    """Minimal PaDiM graph used to isolate KV260 DPU compilation."""
+    """PaDiM graph adapted for KV260 DPU compilation."""
 
     def __init__(self, model: nn.Module) -> None:
         super().__init__()
+
         self.backbone = model.embeddings_extractor.backbone
+        self.layer_indices = model.layer_indices
+
+        self.channel_indices = model.channel_indices
+        self.mahalanobis = MahalanobisDistance(
+            model.mahalanobisDistance._mean_flat,
+            model.mahalanobisDistance._cov_inv_flat,
+        )
 
     def forward(self, x: torch.Tensor):
         x = self.backbone.conv1(x)
         x = self.backbone.bn1(x)
         x = self.backbone.relu(x)
         x = self.backbone.maxpool(x)
+
         features = self.backbone.layer1(x)
 
-        # Return the backbone feature map twice so the existing quantization
-        # script remains unchanged while we isolate compiler compatibility.
-        return features, features
+        batch_size, channels, height, width = features.shape
+
+        features = features.permute(0, 2, 3, 1)
+        features = features.reshape(batch_size, height * width, channels)
+
+        features = features[:, :, self.channel_indices]
+
+        score_map = self.mahalanobis(
+            features,
+            width=width,
+            height=height,
+        )
+
+        image_score = score_map.flatten(1).amax(dim=1)
+
+        return image_score, score_map

--- a/anomavision/quantize/model/backends/xmodel/padim.py
+++ b/anomavision/quantize/model/backends/xmodel/padim.py
@@ -28,10 +28,14 @@ class DpuMahalanobisDistance(nn.Module):
             delta.unsqueeze(2),
             self.cov_inv.unsqueeze(0),
         )
-        dist2 = torch.matmul(
-            left,
-            delta.unsqueeze(-1),
-        ).squeeze(-1).squeeze(-1)
+        dist2 = (
+            torch.matmul(
+                left,
+                delta.unsqueeze(-1),
+            )
+            .squeeze(-1)
+            .squeeze(-1)
+        )
 
         return dist2.clamp_min(0).sqrt().view(batch_size, width, height)
 

--- a/anomavision/quantize/model/backends/xmodel/padim.py
+++ b/anomavision/quantize/model/backends/xmodel/padim.py
@@ -5,7 +5,36 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 
-from .....algorithm.common.mahalanobis import MahalanobisDistance
+
+class DpuMahalanobisDistance(nn.Module):
+    """Mahalanobis distance using DPU-friendly add instead of subtract."""
+
+    def __init__(self, mean: torch.Tensor, cov_inv: torch.Tensor) -> None:
+        super().__init__()
+        self.register_buffer("mean", mean)
+        self.register_buffer("neg_mean", -mean)
+        self.register_buffer("cov_inv", cov_inv)
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        width: int,
+        height: int,
+    ) -> torch.Tensor:
+        batch_size, num_patches, _ = features.shape
+
+        delta = features + self.neg_mean.unsqueeze(0)
+        left = torch.matmul(
+            delta.unsqueeze(2),
+            self.cov_inv.unsqueeze(0),
+        )
+        dist2 = torch.matmul(
+            left,
+            delta.unsqueeze(-1),
+        ).squeeze(-1).squeeze(-1)
+
+        return dist2.clamp_min(0).sqrt().view(batch_size, width, height)
+
 
 class PadimKV260(nn.Module):
     """PaDiM graph adapted for KV260 DPU compilation."""
@@ -15,9 +44,8 @@ class PadimKV260(nn.Module):
 
         self.backbone = model.embeddings_extractor.backbone
         self.layer_indices = model.layer_indices
-
         self.channel_indices = model.channel_indices
-        self.mahalanobis = MahalanobisDistance(
+        self.mahalanobis = DpuMahalanobisDistance(
             model.mahalanobisDistance._mean_flat,
             model.mahalanobisDistance._cov_inv_flat,
         )
@@ -34,7 +62,6 @@ class PadimKV260(nn.Module):
 
         features = features.permute(0, 2, 3, 1)
         features = features.reshape(batch_size, height * width, channels)
-
         features = features[:, :, self.channel_indices]
 
         score_map = self.mahalanobis(

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
 # =========================
 # Dataset / preprocessing (shared by train, detect, eval, stream)
 # =========================
-dataset_path: "/workspace/dataset"               # Root dataset folder (MVTec-style: contains train/test subfolders)
+dataset_path: "D:/01-DATA"               # Root dataset folder (MVTec-style: contains train/test subfolders)
 class_name: "bottle"                     # Class name for MVTec dataset
 resize: [224, 224]                       # Resize dimensions before processing [width, height]
 crop_size:                               # Final crop size [width, height]

--- a/docs/kv260_xmodel.md
+++ b/docs/kv260_xmodel.md
@@ -26,6 +26,12 @@ Both PaDiM and PatchCore use the same basic workflow.
 
 ## 2. Activate Vitis AI
 
+Run Docker with v to dataset and Anomavison
+
+```bash
+docker run --rm -it   -v ~/Vitis-AI/AnomaVision:/workspace/AnomaVision   -v /root/dataset:/workspace/dataset   xilinx/vitis-ai-pytorch-cpu:latest   bash
+```
+
 Activate the Vitis AI PyTorch environment:
 
 ```bash


### PR DESCRIPTION
## 🔗 Related Issue
Fixes #

## 📝 Description

This PR adds and improves KV260 deployment support for PaDiM and PatchCore.

- Added KV260 INT8 quantization and XModel compilation workflows.
- PaDiM compiles to **1 DPU subgraph** on KV260.
- PatchCore compiles to **1 DPU subgraph** on KV260.
- Updated KV260 documentation and deployment instructions.
- Simplified and updated the main README for beginners.
- Added KV260 support badge and updated project documentation.

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change)
- [x] 🚀 New feature
- [ ] 💥 Breaking change
- [x] 📖 Documentation update
- [ ] 🏗️ Infrastructure / CI/CD update

## 🧪 Hardware & Matrix Testing

### KV260 / Vitis AI

- [x] PaDiM INT8 quantization completed
- [x] PaDiM XModel compilation completed
- [x] **PaDiM: 1 DPU subgraph**
- [x] PatchCore INT8 quantization completed
- [x] PatchCore XModel compilation completed
- [x] **PatchCore: 1 DPU subgraph**
- [ ] On-device KV260 validation

### Software

**Host OS used for testing:**

- [x] Linux / Ubuntu
- [ ] Windows (Native or WSL2)
- [ ] macOS

## ✅ Developer Checklist

- [x] Code follows the project style guidelines.
- [x] KV260 quantization and compilation workflows tested.
- [x] Documentation updated.
- [x] Main README simplified for beginners.
- [ ] `uv run pytest` and all unit tests pass locally.
- [ ] Lockfile Guard: `uv.lock` updated if dependencies changed.
- [ ] Additional automated tests added where applicable.

## 📸 Screenshots / Visual Proof

### PaDiM

```text
Total device subgraph number 3
DPU subgraph number 1