### PR TITLE
Test/tensorrt cpu validation

### DIFF
--- a/anomavision/export.py
+++ b/anomavision/export.py
@@ -916,6 +916,7 @@ def _apply_export_defaults(config):
         "quantize_static": False,
         "static_batch": False,
         "optimize": False,
+        "log_level": "INFO",
     }
     for key, value in defaults.items():
         if not hasattr(config, key):

--- a/docs/tensorrt.md
+++ b/docs/tensorrt.md
@@ -1,0 +1,124 @@
+# TensorRT
+
+AnomaVision TensorRT export builds a native NVIDIA TensorRT engine from the model's FP32 ONNX graph.
+
+## What requires an NVIDIA GPU
+
+A real TensorRT engine cannot be built or executed on a CPU-only machine. The following steps require an NVIDIA Linux environment with CUDA, TensorRT, and PyCUDA:
+
+- TensorRT network parsing and engine building
+- FP16/FP32 engine generation
+- INT8 calibration
+- TensorRT engine deserialization and inference
+
+Do **not** install `nvidia-utils` on a CPU-only machine just to test this path. The NVIDIA GPU and driver must actually be available.
+
+## What can be tested on CPU
+
+The repository now includes CPU-only tests for the TensorRT implementation:
+
+```bash
+pytest -q tests/test_tensorrt_cpu_validation.py
+```
+
+These tests verify:
+
+- the main `anomavision export` parser accepts all TensorRT arguments;
+- the standalone `scripts/convert_to_tensorrt.py` parser accepts TensorRT options;
+- `ModelExporter.export_tensorrt()` stops cleanly on CPU before importing TensorRT or PyCUDA;
+- no temporary ONNX file is left behind when the CPU guard is triggered.
+
+You can also verify the CLI help without a GPU:
+
+```bash
+python -m anomavision.cli export --help
+python scripts/convert_to_tensorrt.py --help
+```
+
+## CPU guard test
+
+The expected behavior on a CPU-only machine is a clean TensorRT failure with the message:
+
+```text
+TensorRT export requires a CUDA device.
+```
+
+The export method returns `None`, allowing the CLI to report the failed export instead of crashing during a TensorRT/PyCUDA import.
+
+## Real TensorRT test on NVIDIA Linux
+
+After moving the repository to an NVIDIA Linux machine, verify the environment first:
+
+```bash
+nvidia-smi
+```
+
+Then test the normal export path. For example:
+
+```bash
+anomavision export \
+  --config config.yml \
+  --format tensorrt \
+  --device cuda \
+  --tensorrt-precision fp16
+```
+
+For INT8:
+
+```bash
+anomavision export \
+  --config config.yml \
+  --format tensorrt \
+  --device cuda \
+  --tensorrt-precision int8 \
+  --calib-dir ./dataset/<class>/train/good \
+  --calib-samples 100
+```
+
+The standalone converter is also available:
+
+```bash
+python scripts/convert_to_tensorrt.py \
+  --model ./path/to/model.pth \
+  --output-dir ./engines \
+  --precision fp16 \
+  --device cuda
+```
+
+For INT8:
+
+```bash
+python scripts/convert_to_tensorrt.py \
+  --model ./path/to/model.pth \
+  --output-dir ./engines \
+  --precision int8 \
+  --device cuda \
+  --calib-dir ./dataset/<class>/train/good \
+  --calib-samples 100
+```
+
+## Dynamic batch profiles
+
+TensorRT dynamic export uses:
+
+```text
+min_batch <= opt_batch <= max_batch
+```
+
+Defaults are:
+
+```text
+min_batch = 1
+opt_batch = 1
+max_batch = 4
+```
+
+Use `--static-batch` to disable the optimization profile and build a fixed-batch engine.
+
+## INT8 calibration
+
+TensorRT INT8 calibration intentionally requires real calibration images. Random calibration data is disabled for TensorRT export.
+
+Calibration images are loaded recursively and preprocessed to NCHW FP32 tensors using the same image preprocessing used by AnomaVision.
+
+A reusable TensorRT calibration cache is written next to the engine output.

--- a/tests/test_tensorrt_cpu_validation.py
+++ b/tests/test_tensorrt_cpu_validation.py
@@ -1,0 +1,98 @@
+from unittest.mock import MagicMock
+
+import torch
+
+from anomavision.export import ModelExporter, create_parser
+from scripts.convert_to_tensorrt import build_parser
+
+
+def test_export_parser_accepts_tensorrt_options():
+    args = create_parser().parse_args(
+        [
+            "--model_data_path",
+            "./distributions",
+            "--algorithm",
+            "padim",
+            "--model",
+            "model.pt",
+            "--format",
+            "tensorrt",
+            "--device",
+            "cpu",
+            "--tensorrt-precision",
+            "int8",
+            "--calib-dir",
+            "./calibration",
+            "--calib-samples",
+            "25",
+            "--workspace-gb",
+            "1.5",
+            "--min-batch",
+            "1",
+            "--opt-batch",
+            "2",
+            "--max-batch",
+            "4",
+        ]
+    )
+
+    assert args.format == "tensorrt"
+    assert args.device == "cpu"
+    assert args.tensorrt_precision == "int8"
+    assert args.calib_dir == "./calibration"
+    assert args.calib_samples == 25
+    assert args.workspace_gb == 1.5
+    assert (args.min_batch, args.opt_batch, args.max_batch) == (1, 2, 4)
+
+
+def test_standalone_tensorrt_parser_accepts_cpu_validation_arguments():
+    args = build_parser().parse_args(
+        [
+            "--model",
+            "model.pth",
+            "--output-dir",
+            "engines",
+            "--precision",
+            "fp16",
+            "--device",
+            "cpu",
+        ]
+    )
+
+    assert args.precision == "fp16"
+    assert args.device == "cpu"
+    assert args.input_shape == (1, 3, 224, 224)
+
+
+def test_tensorrt_export_stops_cleanly_on_cpu_without_importing_tensorrt(tmp_path):
+    logger = MagicMock()
+    exporter = ModelExporter(
+        tmp_path / "missing.pt",
+        tmp_path,
+        logger,
+        device="cpu",
+    )
+
+    result = exporter.export_tensorrt(
+        input_shape=(1, 3, 16, 16),
+        output_name="model_fp16.engine",
+        precision="fp16",
+    )
+
+    assert result is None
+    logger.exception.assert_called_once()
+    message = logger.exception.call_args.args[0]
+    assert message == "tensorrt: failed after %.2fs"
+    assert not (tmp_path / "model_fp16_fp32.onnx").exists()
+
+
+def test_cpu_tensor_device_is_used_by_exporter(tmp_path):
+    logger = MagicMock()
+    exporter = ModelExporter(
+        tmp_path / "missing.pt",
+        tmp_path,
+        logger,
+        device="cpu",
+    )
+
+    assert exporter.device == torch.device("cpu")


### PR DESCRIPTION
## 🔗 Related Issue

Fixes #

## 📝 Description

* Added CPU validation for the TensorRT export path.
* Fixed missing export CLI defaults.
* Validated PyTorch → ONNX → ONNX Runtime on Linux CPU.
* TensorRT correctly requires CUDA/NVIDIA GPU.

## 🔄 Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] 🚀 New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] 📖 Documentation update
* [ ] 🏗️ Infrastructure / CI/CD update

## 🧪 Hardware & Matrix Testing

**I have successfully built and tested this code using `uv` on:**

* [x] `anomavision[cpu]` (Standard/Edge)
* [ ] `anomavision[cu121]` (CUDA 12.1)
* [ ] `anomavision[cu124]` (CUDA 12.4)
* [ ] `anomavision[cu118]` (CUDA 11.8)

**Host OS used for testing:**

* [x] Linux / Ubuntu
* [ ] Windows (Native or WSL2)
* [ ] macOS

## ✅ Developer Checklist

* [x] My code follows the core style guidelines of this project (Ruff/Black formatting).
* [ ] I have run `uv run pytest` and all unit tests pass locally.
* [ ] **Lockfile Guard:** If I added or modified a dependency in `pyproject.toml`, I have run `uv lock --python 3.10` and committed the updated `uv.lock` file.
* [x] I have added tests that prove my fix is effective or that my feature works.
* [x] I have updated the documentation accordingly.

## 📸 Screenshots / Visual Proof (Optional)

* CPU TensorRT validation: **4 tests passed**
* ONNX validation: **OK**
* ONNX Runtime inference: **OK**
* TensorRT CPU guard: **correctly rejects export without CUDA**
