### PR TITLE
Add single-image model validation with score and heatmap

### DIFF
--- a/anomavision/cli.py
+++ b/anomavision/cli.py
@@ -8,12 +8,7 @@ Usage:
     anomavision export [args...]     # Export model to different formats
     anomavision detect [args...]     # Run inference on images
     anomavision eval [args...]       # Evaluate model performance
-
-Examples:
-    anomavision train --config config.yml
-    anomavision export --config config.yml --model model.pt --format onnx
-    anomavision detect --config config.yml --model model.onnx --img_path ./test_images
-    anomavision eval --config config.yml --model model.pt --class_name bottle
+    anomavision validate [args...]   # Validate one image and save a heatmap
 """
 
 import argparse
@@ -21,9 +16,6 @@ import sys
 
 # Submodules are imported lazily inside _add_*_parser() and _dispatch_*().
 # CLI startup (including --help on the top-level parser) never touches torch/cv2.
-# Note: --help on a subcommand (e.g. `anomavision train --help`) WILL import
-# the submodule to build the parser — that is intentional and unavoidable if we
-# want the submodule to own its argument definitions.
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -38,12 +30,14 @@ Examples:
   %(prog)s export --model model.pt --format onnx --quantize-dynamic
   %(prog)s detect --model model.onnx --img_path ./test --enable_visualization
   %(prog)s eval --model model.pt --class_name bottle --dataset_path /data
+  %(prog)s validate --image test.png --model model.pt
 
 For detailed help on each command:
   %(prog)s train --help
   %(prog)s export --help
   %(prog)s detect --help
   %(prog)s eval --help
+  %(prog)s validate --help
         """,
     )
 
@@ -69,25 +63,9 @@ For detailed help on each command:
     _add_detect_parser(subparsers)
     _add_eval_parser(subparsers)
     _add_autopilot_parser(subparsers)
+    _add_validate_parser(subparsers)
 
     return parser
-
-
-# ============================================================
-# Subparser registration
-#
-# Each submodule owns its argument definitions in create_parser().
-# cli.py uses `parents=` to inherit all args — zero duplication.
-#
-# The key: call create_parser(add_help=False) so argparse doesn't
-# register -h on the parent. The child subparser adds its own -h
-# automatically. Setting add_help at *construction time* is the
-# only reliable way — mutating .add_help after construction does
-# not remove the already-registered -h action.
-#
-# Result: add --new-flag to detect.py and `anomavision detect --new-flag`
-# works immediately with no changes needed here.
-# ============================================================
 
 
 def _add_train_parser(subparsers) -> None:
@@ -145,10 +123,15 @@ def _add_autopilot_parser(subparsers) -> None:
     ).set_defaults(func=_dispatch_autopilot)
 
 
-# ============================================================
-# Dispatch functions — one line each, Namespace passed directly.
-# No sys.argv manipulation. No double-parsing.
-# ============================================================
+def _add_validate_parser(subparsers) -> None:
+    from anomavision.validate import create_parser as _cp
+
+    subparsers.add_parser(
+        "validate",
+        help="Validate one image and save score/heatmap results",
+        parents=[_cp(add_help=False)],
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    ).set_defaults(func=_dispatch_validate)
 
 
 def _dispatch_train(args: argparse.Namespace) -> None:
@@ -170,7 +153,7 @@ def _dispatch_detect(args: argparse.Namespace) -> None:
 
 
 def _dispatch_eval(args: argparse.Namespace) -> None:
-    from anomavision import eval as eval_module  # 'eval' shadows the Python builtin
+    from anomavision import eval as eval_module
 
     eval_module.main(args)
 
@@ -181,9 +164,10 @@ def _dispatch_autopilot(args: argparse.Namespace) -> None:
     autopilot.main(args)
 
 
-# ============================================================
-# Entry point
-# ============================================================
+def _dispatch_validate(args: argparse.Namespace) -> None:
+    from anomavision import validate
+
+    validate.main(args)
 
 
 def main() -> None:

--- a/anomavision/validate.py
+++ b/anomavision/validate.py
@@ -1,0 +1,267 @@
+"""Single-image validation for AnomaVision models.
+
+Runs one image through a PyTorch, ONNX, or (when a device is available) Hailo
+model and writes a simple original/heatmap result image. PT and ONNX use the
+same configurable preprocessing as the normal AnomaVision inference pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import cv2
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from PIL import Image
+
+from anomavision.config import _shape, load_config
+from anomavision.inference.model.wrapper import ModelWrapper
+from anomavision.utils import create_image_transform, merge_config, resolve_threshold
+
+matplotlib.use("Agg")
+
+
+def create_parser(add_help: bool = True) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate one image with a PyTorch, ONNX, or Hailo model.",
+        add_help=add_help,
+    )
+    parser.add_argument("--image", required=True, help="Input image path.")
+    parser.add_argument(
+        "--model", required=True, help="Model path (.pt/.pth, .onnx, or .hef)."
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Optional config file used for preprocessing and threshold settings.",
+    )
+    parser.add_argument(
+        "--algorithm", default=None, help="Algorithm name, e.g. patchcore or padim."
+    )
+    parser.add_argument(
+        "--device",
+        default="cpu",
+        choices=["cpu", "cuda"],
+        help="Device for PT/ONNX inference. Hailo uses the connected Hailo device.",
+    )
+    parser.add_argument(
+        "--threshold",
+        "--thresh",
+        dest="threshold",
+        type=float,
+        default=None,
+        help="Optional anomaly threshold. If omitted, no anomaly/normal label is shown.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="./validation_results",
+        help="Directory for result images and JSON output.",
+    )
+    parser.add_argument(
+        "--name", default=None, help="Output name. Defaults to the input image stem."
+    )
+    parser.add_argument(
+        "--alpha", type=float, default=0.5, help="Heatmap overlay opacity."
+    )
+    parser.add_argument(
+        "--compare-model",
+        default=None,
+        help="Optional second PT/ONNX model. Both models are run on the same image.",
+    )
+    return parser
+
+
+def _load_settings(args: argparse.Namespace) -> Dict:
+    config = load_config(args.config) if args.config else {}
+    return merge_config(args, config)
+
+
+def _preprocess(image: Image.Image, settings: Dict) -> torch.Tensor:
+    resize = _shape(settings.get("resize", [224, 224]))
+    crop_size = _shape(settings.get("crop_size", None))
+    transform = create_image_transform(
+        resize=resize,
+        crop_size=crop_size,
+        normalize=bool(settings.get("normalize", True)),
+        mean=settings.get("norm_mean", [0.485, 0.456, 0.406]),
+        std=settings.get("norm_std", [0.229, 0.224, 0.225]),
+    )
+    return transform(image).unsqueeze(0)
+
+
+def _run_model(
+    model_path: str, image: Image.Image, settings: Dict, device: str
+) -> Tuple[float, np.ndarray, float]:
+    """Run one model and return score, score map, and inference time in ms."""
+    suffix = Path(model_path).suffix.lower()
+    wrapper = ModelWrapper(model_path, device)
+    try:
+        if suffix == ".hef":
+            # HailoBackend owns its device-side preprocessing and expects RGB HWC.
+            model_input = np.asarray(image.convert("RGB"))
+        else:
+            model_input = _preprocess(image.convert("RGB"), settings)
+
+        start = time.perf_counter()
+        scores, maps = wrapper.predict(model_input)
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+    finally:
+        wrapper.close()
+
+    score = float(np.asarray(scores).reshape(-1)[0])
+    score_map = np.asarray(maps).squeeze().astype(np.float32)
+    if score_map.ndim != 2:
+        raise RuntimeError(
+            f"Expected a 2-D score map for visualization, got shape {score_map.shape}."
+        )
+    return score, score_map, elapsed_ms
+
+
+def _make_heatmap(image: np.ndarray, score_map: np.ndarray, alpha: float) -> np.ndarray:
+    """Create an RGB heatmap overlay with robust normalization."""
+    height, width = image.shape[:2]
+    score_map = cv2.resize(score_map, (width, height), interpolation=cv2.INTER_LINEAR)
+    finite = score_map[np.isfinite(score_map)]
+    if finite.size == 0:
+        normalized = np.zeros_like(score_map, dtype=np.float32)
+    else:
+        low = float(finite.min())
+        high = float(finite.max())
+        if high <= low:
+            normalized = np.zeros_like(score_map, dtype=np.float32)
+        else:
+            normalized = np.clip((score_map - low) / (high - low), 0.0, 1.0)
+
+    heat = cv2.applyColorMap((normalized * 255).astype(np.uint8), cv2.COLORMAP_JET)
+    heat = cv2.cvtColor(heat, cv2.COLOR_BGR2RGB)
+    return cv2.addWeighted(image, 1.0 - alpha, heat, alpha, 0.0)
+
+
+def _save_result(
+    image: np.ndarray,
+    score_map: np.ndarray,
+    score: float,
+    output_path: Path,
+    title: str,
+    threshold: Optional[float],
+    alpha: float,
+) -> None:
+    heatmap = _make_heatmap(image, score_map, alpha)
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+    axes[0].imshow(image)
+    axes[0].set_title("Input")
+    axes[0].axis("off")
+    axes[1].imshow(heatmap)
+    label = ""
+    if threshold is not None:
+        label = " | ANOMALY" if score >= threshold else " | NORMAL"
+    axes[1].set_title(f"Heatmap | score={score:.6f}{label}")
+    axes[1].axis("off")
+    fig.suptitle(title)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _run(args: argparse.Namespace) -> int:
+    image_path = Path(args.image)
+    model_path = Path(args.model)
+    if not image_path.is_file():
+        raise FileNotFoundError(f"Image not found: {image_path}")
+    if not model_path.is_file():
+        raise FileNotFoundError(f"Model not found: {model_path}")
+
+    settings = _load_settings(args)
+    if args.algorithm:
+        settings["algorithm"] = args.algorithm
+    threshold = args.threshold
+    if threshold is None:
+        threshold = resolve_threshold(settings)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = args.name or image_path.stem
+    image = Image.open(image_path).convert("RGB")
+    image_np = np.asarray(image)
+
+    models = [str(model_path)]
+    if args.compare_model:
+        compare_path = Path(args.compare_model)
+        if not compare_path.is_file():
+            raise FileNotFoundError(f"Comparison model not found: {compare_path}")
+        models.append(str(compare_path))
+
+    results = []
+    for path in models:
+        score, score_map, elapsed_ms = _run_model(path, image, settings, args.device)
+        model_name = Path(path).stem
+        result_path = output_dir / f"{stem}_{model_name}_result.png"
+        _save_result(
+            image_np,
+            score_map,
+            score,
+            result_path,
+            f"{model_name} ({Path(path).suffix.lower()})",
+            threshold,
+            args.alpha,
+        )
+        result = {
+            "model": path,
+            "score": score,
+            "inference_ms": elapsed_ms,
+            "threshold": threshold,
+            "classification": (
+                "anomaly"
+                if threshold is not None and score >= threshold
+                else "normal"
+                if threshold is not None
+                else None
+            ),
+            "result_image": str(result_path),
+            "score_map_shape": list(score_map.shape),
+        }
+        results.append(result)
+        print(f"{model_name}: score={score:.6f}, inference={elapsed_ms:.2f} ms")
+        if threshold is not None:
+            print(
+                f"  classification={'ANOMALY' if score >= threshold else 'NORMAL'} "
+                f"(threshold={threshold})"
+            )
+        print(f"  result={result_path}")
+
+    if len(results) == 2:
+        a, b = results
+        diff = abs(a["score"] - b["score"])
+        relative = diff / max(abs(a["score"]), abs(b["score"]), 1e-12)
+        comparison = {
+            "model_a": a["model"],
+            "model_b": b["model"],
+            "score_absolute_difference": diff,
+            "score_relative_difference": relative,
+        }
+        results.append({"comparison": comparison})
+        print(f"score difference={diff:.6f} ({relative * 100:.3f}% relative)")
+
+    json_path = output_dir / f"{stem}_results.json"
+    json_path.write_text(
+        json.dumps({"image": str(image_path), "results": results}, indent=2),
+        encoding="utf-8",
+    )
+    print(f"  metrics={json_path}")
+    return 0
+
+
+def main(args: Optional[argparse.Namespace] = None) -> None:
+    if args is None:
+        args = create_parser().parse_args()
+    raise SystemExit(_run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,16 +1,17 @@
 # 🛠️ CLI Reference
 
-AnomaVision provides a unified `anomavision` command with five subcommands:
+AnomaVision provides a unified `anomavision` command with six subcommands:
 
 ```bash
-anomavision train    # Train a PaDiM anomaly detection model
-anomavision detect   # Run inference on test images
-anomavision eval     # Evaluate performance on MVTec-style datasets
-anomavision export   # Export models to ONNX, TorchScript, OpenVINO, or TensorRT
+anomavision train     # Train a PaDiM anomaly detection model
+anomavision detect    # Run inference on test images
+anomavision eval      # Evaluate performance on MVTec-style datasets
+anomavision export    # Export models to ONNX, TorchScript, OpenVINO, or TensorRT
 anomavision autopilot # Calibrate, profile, and package a production model
+anomavision validate  # Validate one image and save its score + heatmap
 ```
 
-Each subcommand accepts both **CLI arguments** and **config files** (`--config config.yml`).
+Each subcommand accepts both **CLI arguments** and config files (`--config config.yml`).
 **CLI arguments always override config file values.**
 
 Get help at any level:
@@ -22,6 +23,7 @@ anomavision detect --help
 anomavision eval --help
 anomavision export --help
 anomavision autopilot --help
+anomavision validate --help
 ```
 
 ---
@@ -46,10 +48,10 @@ anomavision train [options]
 | `--batch_size`      | int      | 2               | Batch size                                           |
 | `--feat_dim`        | int      | 50              | Number of random features                            |
 | `--layer_indices`   | int list | [0]             | Backbone layer indices                               |
-| `--output_model`    | str      | model.pt  | Model filename (`.pt`)                               |
-| `--run_name`        | str      | anomav_exp       | Experiment name                                      |
+| `--output_model`    | str      | model.pt        | Model filename (`.pt`)                               |
+| `--run_name`        | str      | anomav_exp      | Experiment name                                      |
 | `--model_data_path` | str      | ./distributions | Output directory                                     |
-| `--log_level`       | str      | INFO            | Logging level                                        |
+| `--log_level`       | str      | INFO             | Logging level                                        |
 
 **Example:**
 
@@ -73,8 +75,8 @@ anomavision detect [options]
 | ------------------------ | ----- | ------------------------- | -------------------------------------- |
 | `--config`               | str   | None                      | Path to config file                    |
 | `--img_path`             | str   | None                      | Path to test images                    |
-| `--model_data_path`      | str   | ./distributions/anomav_exp | Directory with model files             |
-| `--model`                | str   | model.pt            | Model file (`.pt`, `.onnx`, `.engine`) |
+| `--model_data_path`      | str   | ./distributions            | Directory with model files             |
+| `--model`                | str   | model.pt                  | Model file (`.pt`, `.onnx`, `.engine`) |
 | `--device`               | str   | auto                      | Device (`cpu`, `cuda`, `auto`)         |
 | `--batch_size`           | int   | 1                         | Batch size                             |
 | `--thresh`               | float | None                      | Anomaly threshold                      |
@@ -101,7 +103,61 @@ anomavision detect \
 
 ---
 
-## 3. Evaluation — `anomavision eval`
+## 3. Single-image validation — `anomavision validate`
+
+Use this when you have one image and want a quick **anomaly score + heatmap** without running a complete test dataset.
+
+```bash
+anomavision validate \
+  --image ./dataset/bottle/test/broken/000.png \
+  --model ./distributions/patchcore/bottle/anomav_exp/model.pt \
+  --config examples/patchcore_cpu.yml
+```
+
+The command writes a result image and a JSON file to `./validation_results/`.
+
+### Compare PyTorch and ONNX
+
+Run both models on exactly the same input image:
+
+```bash
+anomavision validate \
+  --image ./dataset/bottle/test/broken/000.png \
+  --model ./distributions/patchcore/bottle/anomav_exp/model.pt \
+  --compare-model ./distributions/patchcore/bottle/anomav_exp/model.onnx \
+  --config examples/patchcore_cpu.yml
+```
+
+The terminal reports the score and inference time for each model, followed by the absolute and relative score difference. Each model also gets its own visualization, and the JSON file contains the comparison values.
+
+### Threshold
+
+A threshold can be supplied directly or taken from the config:
+
+```bash
+anomavision validate \
+  --image ./test.png \
+  --model ./model.pt \
+  --threshold 0.35
+```
+
+For PatchCore, use the threshold calibrated for your model. Do not assume a PaDiM threshold is valid for PatchCore.
+
+### Hailo HEF
+
+The same command accepts a complete AnomaVision `.hef`:
+
+```bash
+anomavision validate \
+  --image ./test.png \
+  --model ./anomavision_patchcore_k26_end_to_end.hef
+```
+
+The Hailo backend is already wired into the common inference interface, but **HEF execution requires HailoRT and a connected Hailo device**. A CPU-only machine can validate PT and ONNX, but it cannot execute the HEF.
+
+---
+
+## 4. Evaluation — `anomavision eval`
 
 ```bash
 anomavision eval [options]
@@ -112,8 +168,8 @@ anomavision eval [options]
 | `--config`               | str  | None                      | Path to config file        |
 | `--dataset_path`         | str  | None                      | Root dataset path          |
 | `--class_name`           | str  | bottle                    | Class name (MVTec style)   |
-| `--model_data_path`      | str  | ./distributions/anomav_exp | Directory with model files |
-| `--model`                | str  | model.onnx          | Model file                 |
+| `--model_data_path`      | str  | ./distributions            | Directory with model files |
+| `--model`                | str  | model.onnx                | Model file                 |
 | `--device`               | str  | auto                      | Device (`cpu`, `cuda`)     |
 | `--batch_size`           | int  | 32                        | Batch size                 |
 | `--num_workers`          | int  | 1                         | Data loader workers        |
@@ -136,7 +192,7 @@ anomavision eval \
 
 ---
 
-## 4. Export — `anomavision export`
+## 5. Export — `anomavision export`
 
 ```bash
 anomavision export [options]
@@ -145,7 +201,7 @@ anomavision export [options]
 | Argument             | Type | Default                   | Description                                              |
 | -------------------- | ---- | ------------------------- | -------------------------------------------------------- |
 | `--config`           | str  | None                      | Path to config file                                      |
-| `--model_data_path`  | str  | ./distributions/anomav_exp | Directory with model & outputs                           |
+| `--model_data_path`  | str  | ./distributions            | Directory with model & outputs                           |
 | `--model`            | str  | *(required)*              | Model file (`.pt`)                                       |
 | `--format`           | str  | *(required)*              | Export format (`onnx`, `torchscript`, `openvino`, `all`) |
 | `--device`           | str  | auto                      | Export device                                            |
@@ -171,7 +227,7 @@ anomavision export \
 
 ---
 
-## 5. Production Autopilot — `anomavision autopilot`
+## 6. Production Autopilot — `anomavision autopilot`
 
 Production Autopilot compares PaDiM and ultra-light PatchCore artifacts on the same complete labeled test split, calibrates algorithm-specific thresholds, measures latency, checks localization health, and creates a deployment package.
 


### PR DESCRIPTION
## Summary
- add `anomavision validate` for single-image inference
- support PyTorch and ONNX on CPU without a Hailo device
- save original + heatmap visualization and JSON metrics
- optionally compare PT vs ONNX on the exact same image
- keep `.hef` support ready through the existing Hailo backend; execution still requires HailoRT and hardware
- document the workflow in `docs/cli.md`

## Example
```bash
anomavision validate \
  --image ./test.png \
  --model ./distributions/patchcore/bottle/anomav_exp/model.pt \
  --compare-model ./distributions/patchcore/bottle/anomav_exp/model.onnx \
  --config examples/patchcore_cpu.yml
```

The command prints scores/latency, saves per-model result images, and writes a JSON comparison.